### PR TITLE
(GH-85) Update to Cake.Issues 0.8.0

### DIFF
--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Issues" Version="0.7.0" />
-    <PackageReference Include="Cake.Issues.Testing" Version="0.7.0" />
+    <PackageReference Include="Cake.Issues" Version="0.8.0-beta0001" />
+    <PackageReference Include="Cake.Issues.Testing" Version="0.8.0-beta0001" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Issues" Version="0.7.0" />
+    <PackageReference Include="Cake.Issues" Version="0.8.0-beta0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>

--- a/src/Cake.Issues.Reporting/IssueReportCreator.cs
+++ b/src/Cake.Issues.Reporting/IssueReportCreator.cs
@@ -40,7 +40,7 @@
             reportFormat.NotNull(nameof(reportFormat));
 
             var issuesReader = new IssuesReader(this.log, issueProviders, this.settings);
-            var issues = issuesReader.ReadIssues(IssueCommentFormat.PlainText);
+            var issues = issuesReader.ReadIssues();
 
             return this.CreateReport(issues, reportFormat);
         }


### PR DESCRIPTION
Update to Cake.Issues 0.8.0 and add support for different message formats in reports.

Fixes #85 